### PR TITLE
Add double-click to toggle checkbox in FixCommonErrors

### DIFF
--- a/src/UI/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
+++ b/src/UI/Features/Tools/FixCommonErrors/FixCommonErrorsWindow.cs
@@ -117,6 +117,13 @@ public class FixCommonErrorsWindow : Window
                 item.IsSelected = !item.IsSelected;
             }
         };
+        rulesGrid.DoubleTapped += (sender, e) =>
+        {
+            if (rulesGrid.SelectedItem is FixRuleDisplayItem item)
+            {
+                item.IsSelected = !item.IsSelected;
+            }
+        };
 
         var step2Grid = MakeStep2Grid();
         step2Grid.Bind(IsVisibleProperty, new Binding(nameof(_vm.Step2IsVisible)));
@@ -287,6 +294,13 @@ public class FixCommonErrorsWindow : Window
         };
         dataGridFixes.Bind(DataGrid.SelectedItemProperty, new Binding(nameof(_vm.SelectedFix)));
         dataGridFixes.SelectionChanged += DataGridFixes_SelectionChanged;
+        dataGridFixes.DoubleTapped += (sender, e) =>
+        {
+            if (dataGridFixes.SelectedItem is FixDisplayItem item)
+            {
+                item.IsSelected = !item.IsSelected;
+            }
+        };
 
         var buttonBarFixes = UiUtil.MakeButtonBar(
             UiUtil.MakeButton("Select all", _vm.FixesSelectAllCommand),


### PR DESCRIPTION
## Summary
- Double-clicking a row in the **rules grid** (step 1) now toggles the enabled checkbox for that rule
- Double-clicking a row in the **fixes grid** (step 2) now toggles the apply checkbox for that fix

## Test plan
- [ ] Open Fix Common Errors dialog
- [ ] In step 1, double-click a rule row and verify the checkbox toggles
- [ ] In step 2, double-click a fix row and verify the checkbox toggles
- [ ] Verify single-click on checkbox still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)