### PR TITLE
Fix two bugs in NextWordInDoNotBreakList

### DIFF
--- a/src/libse/Common/PlainTextImporter.cs
+++ b/src/libse/Common/PlainTextImporter.cs
@@ -141,9 +141,9 @@ namespace Nikse.SubtitleEdit.Core.Common
 
         private bool NextWordInDoNotBreakList(string text, int index)
         {
-            for (var i = index + 1; i < text.Length || i > 50; i++)
+            for (var i = index + 1; i < text.Length && i - index < 50; i++)
             {
-                var ch = text[index];
+                var ch = text[i];
                 if (ch == '\0')
                 {
                     return false;


### PR DESCRIPTION
## Summary

- Loop condition used `||` instead of `&&`, making `i > 50` always true and causing out-of-bounds access on `text`
- Loop body read `text[index]` (fixed position) instead of `text[i]`, so the same character was inspected every iteration instead of advancing through the word

## Test plan

- [ ] Import plain text with phrases like "Mr. Smith goes to..." and verify line breaks are not inserted after "Mr."
- [ ] Verify no `IndexOutOfRangeException` occurs during plain text import

🤖 Generated with [Claude Code](https://claude.com/claude-code)